### PR TITLE
Fix zotero item sync counter

### DIFF
--- a/src/zotero.ts
+++ b/src/zotero.ts
@@ -392,7 +392,7 @@ export class ZoteroClient implements IReferenceProvider {
           new URLSearchParams(new URL(next).search).entries()
         );
         if (nextParams.start) {
-          i += parseInt(nextParams.start, 10);
+          i = parseInt(nextParams.start, 10);
           if (progress) {
             progress((100 * i) / total);
           }


### PR DESCRIPTION
Rather than increment by page start index we set counter to start index. This resolves issue for me and now all my library syncs through.