### PR TITLE
Bump to final 1.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-citation-manager",
-    "version": "1.0.0-alpha.1",
+    "version": "1.0.0",
     "description": "Citation Manager for JupyterLab with Zotero integration",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Bumps version to final. I will release once anyone comments back on https://github.com/krassowski/jupyterlab-citation-manager/issues/64